### PR TITLE
Escape single quotes in JSON

### DIFF
--- a/.changes/unreleased/Fixes-20251003-142823.yaml
+++ b/.changes/unreleased/Fixes-20251003-142823.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Escape single quotes when inserting JSON in BigQuery
+time: 2025-10-03T14:28:23.346739+02:00
+custom:
+    Author: joar
+    Issue: "24"

--- a/macros/get_adapter_datatypes.sql
+++ b/macros/get_adapter_datatypes.sql
@@ -20,7 +20,7 @@
 
 {% macro type_json_insert(data) %}
   {% if target.type == 'bigquery' %}
-    {{ return('json ' ~ "'" ~ data ~ "'") }}
+    {{ return('json ' ~ "'" ~ (data | replace("\\", "\\\\") | replace("'", "\\'")) ~ "'") }}
   {% else  %}
     {{ return( 'parse_json(' ~ "'" ~ data ~ "'" ~ ')' )  }}
   {% endif %}


### PR DESCRIPTION
resolves #24

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

This method of escaping quotes and escaping backslashes so that we won't escape backslashes that already escape quotes is taken from memory, and is the best practices of escaping untrusted user input from when I was writing MySQL queries using PHP and string concatenation back in 2007, I can't tell you if it's foolproof. If there is a jinja filter that does this, then I have been unable to find it.

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-oss-template/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-oss-template/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
