### PR TITLE
Pin GitHub Actions to specific SHAs (3 actions in 2 files)

### DIFF
--- a/.github/workflows/codeowners-check.yml
+++ b/.github/workflows/codeowners-check.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
       - uses: mszostok/codeowners-validator@f555ba682ec613249e7e478a4e0bff3ba35dc79f # v0.7.2
         with:
           github_access_token: "${{ secrets.OWNERS_VALIDATOR_GITHUB_SECRET }}"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -92,10 +92,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # actions/setup-python@v4
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## 📌 Pin GitHub Actions to Specific SHAs

This PR updates GitHub Actions references from tags/branches to specific commit SHAs for improved security and reproducibility.

### 📊 Summary
- **Files changed**: 2
- **Actions pinned**: 3

### 📝 Changes by file

#### `.github/workflows/integration_tests.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`
- 📌 `actions/setup-python@v4` → `actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # actions/setup-python@v4`

#### `.github/workflows/codeowners-check.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`

