### PR TITLE
add slot ms capacity calculation

### DIFF
--- a/models/rpt_daily_sao_model_savings_bigquery.sql
+++ b/models/rpt_daily_sao_model_savings_bigquery.sql
@@ -14,6 +14,7 @@
 -- BigQuery Pricing: Handles both on-demand ($6.25/TiB default) and slot-based pricing
 
 {% set bigquery_on_demand_price_per_tib = var('bigquery_on_demand_price_per_tib', 6.25) %}
+{% set bigquery_slot_ms_per_hour = var('bigquery_slot_ms_per_hour', 0.04) %}
 
 with model_queries as (
   select
@@ -25,6 +26,11 @@ with model_queries as (
     avg(on_demand_cost) as avg_run_on_demand_cost,
     max(on_demand_cost) as max_run_on_demand_cost,
     sum(on_demand_cost) as total_run_on_demand_cost,
+
+    -- Capacity cost aggregations (slot hours)
+    avg(capacity_cost) as avg_run_capacity_cost,
+    max(capacity_cost) as max_run_capacity_cost,
+    sum(capacity_cost) as total_run_capacity_cost,
 
     -- Slot usage aggregations
     avg(slot_minutes) as avg_run_slot_minutes,
@@ -58,7 +64,7 @@ with model_queries as (
       -- Calculate on-demand cost per query
       -- Convert bytes to TiB (1 TiB = 1024^4 bytes) and multiply by price
       (total_bytes_billed / pow(1024, 4)) * {{ bigquery_on_demand_price_per_tib }} as on_demand_cost,
-
+      (total_slot_ms / 3600000) * {{ bigquery_slot_ms_per_hour }} as capacity_cost,
       slot_minutes,
       job_avg_slots,
       total_bytes_billed,
@@ -98,10 +104,15 @@ select
   reused_models.reuse_count,
   reused_models.unique_runs_reused,
 
-  -- Historical on-demand cost metrics (what it would have cost if not reused)
+  -- Historical on-demand cost metrics
   model_queries.avg_run_on_demand_cost,
   model_queries.max_run_on_demand_cost,
   model_queries.total_run_on_demand_cost,
+
+  -- Historical on-demand cost metrics
+  model_queries.avg_run_capacity_cost,
+  model_queries.max_run_capacity_cost,
+  model_queries.total_run_capacity_cost,
 
   -- Historical slot usage metrics
   model_queries.avg_run_slot_minutes,


### PR DESCRIPTION
### Description
Add support for calculating cost saved based on slot ms. This is a super rough method

Note that for hybrid billing situations we should aggregate both on demand and slot attributed cost to correctly get the total.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-oss-template/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-oss-template/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
